### PR TITLE
Optimization of SchoolService injection

### DIFF
--- a/src/ApiControllers/FAHPController.cs
+++ b/src/ApiControllers/FAHPController.cs
@@ -13,7 +13,6 @@ namespace KonSchool.ApiControllers
         [HttpGet("{numbers}")]
         public ActionResult<IEnumerable<double>> Get(string numbers)
         {
-            Console.WriteLine("NUMBERS " + numbers);
             int[] values;
             try
             {

--- a/src/Models/Query.cs
+++ b/src/Models/Query.cs
@@ -26,15 +26,14 @@ namespace KonSchool.Models
 
         private static readonly object key = new object();
         private static List<string> occupations;
-        public List<School> Alternatives;
+        public List<School> Alternatives
+        {
+            get => _SchoolService?.GetSchools()?.ToList() ?? alternatives ?? new List<School>();
+            set => alternatives = value;
+        }
+        private List<School> alternatives;
 
         public ISchoolService _SchoolService { get; set; }
-
-        public Query(ISchoolService schoolService)
-        {
-            _SchoolService = schoolService;
-            Alternatives = _SchoolService.GetSchools().ToList();
-        }
 
         public static List<string> Occupations
         {

--- a/src/Pages/Inputs.cshtml.cs
+++ b/src/Pages/Inputs.cshtml.cs
@@ -22,7 +22,6 @@ namespace KonSchool.Pages
         public IActionResult OnPost()
         {
             var compmat = Inference.ComparisonMatrix(Values);
-            foreach (var value in Values) Console.WriteLine(value);
             _Query.CompMat = compmat;
             _Query.Weights = new FAHP(compmat).CriteriaWeights;
             return RedirectToPage("/Outputs");

--- a/src/Pages/Inputs.cshtml.cs
+++ b/src/Pages/Inputs.cshtml.cs
@@ -22,6 +22,7 @@ namespace KonSchool.Pages
         public IActionResult OnPost()
         {
             var compmat = Inference.ComparisonMatrix(Values);
+            foreach (var value in Values) Console.WriteLine(value);
             _Query.CompMat = compmat;
             _Query.Weights = new FAHP(compmat).CriteriaWeights;
             return RedirectToPage("/Outputs");

--- a/src/Pages/Outputs.cshtml
+++ b/src/Pages/Outputs.cshtml
@@ -55,7 +55,7 @@
             </tr>
         </thead>
         <tbody>
-            @foreach (var s in Model._Query.Alternatives)
+            @foreach (var s in Model.Schools)
             {
                 <tr>
                     <td>@s.Name</td>

--- a/src/Pages/Outputs.cshtml.cs
+++ b/src/Pages/Outputs.cshtml.cs
@@ -15,6 +15,8 @@ namespace KonSchool.Pages
         public Query _Query { get; set; }
         public ISchoolService _SchoolService;
 
+        public List<School> Schools { get; set; }
+
         public OutputsModel(Query query, ISchoolService schoolService)
         {
             _Query = query;
@@ -35,16 +37,15 @@ namespace KonSchool.Pages
             };
 
             StdDev = Stat.StdDev(_Query.Weights);
+            _Query._SchoolService = _SchoolService;
 
             double[] w = _Query.Weights;
             _Query.SetValues();
-
-            _Query._SchoolService = _SchoolService;
             
             foreach (School s in _Query.Alternatives)
                 s.FinalScore = s.TSR * w[0] + s.MFR * w[1] + s.SES * w[2] + s.LOC * w[3] + s.OLD * w[4] + s.ADS * w[5];
                    
-            _Query.Alternatives = _Query.Alternatives.OrderByDescending(x => x.FinalScore).ToList();
+            Schools = _Query.Alternatives.OrderByDescending(x => x.FinalScore).ToList();
         }
 
         public string ToShortNumber(double number) => string.Format("{0:0.00}%", number * 100);

--- a/src/Pages/Outputs.cshtml.cs
+++ b/src/Pages/Outputs.cshtml.cs
@@ -13,10 +13,12 @@ namespace KonSchool.Pages
     public class OutputsModel : PageModel
     {
         public Query _Query { get; set; }
+        public ISchoolService _SchoolService;
 
-        public OutputsModel(Query query)
+        public OutputsModel(Query query, ISchoolService schoolService)
         {
             _Query = query;
+            _SchoolService = schoolService;
         }
 
         [BindProperty] public string[] Criteria { get; set; }
@@ -36,7 +38,8 @@ namespace KonSchool.Pages
 
             double[] w = _Query.Weights;
             _Query.SetValues();
-            
+
+            _Query._SchoolService = _SchoolService;
             
             foreach (School s in _Query.Alternatives)
                 s.FinalScore = s.TSR * w[0] + s.MFR * w[1] + s.SES * w[2] + s.LOC * w[3] + s.OLD * w[4] + s.ADS * w[5];

--- a/src/Services/SchoolService.cs
+++ b/src/Services/SchoolService.cs
@@ -22,17 +22,13 @@ namespace KonSchool.Services
             // Set credentials to use for this request.
             request.Credentials = CredentialCache.DefaultCredentials;
             HttpWebResponse response = (HttpWebResponse)request.GetResponse();
-
-            // Console.WriteLine("Content length is {0}", response.ContentLength);
-            // Console.WriteLine("Content type is {0}", response.ContentType);
              
             // Get the stream associated with the response.
             Stream receiveStream = response.GetResponseStream();
 
             // Pipes the stream to a higher level stream reader with the required encoding format. 
             StreamReader readStream = new StreamReader(receiveStream, Encoding.UTF8);
-
-            // Console.WriteLine("Response stream received.");
+            
             string json = readStream.ReadToEnd();
             Schools = JsonConvert.DeserializeObject<List<School>>(json);
 

--- a/tests/ModelTests/Query.test.cs
+++ b/tests/ModelTests/Query.test.cs
@@ -10,7 +10,7 @@ namespace KonSchool.Tests.ModelTests
         [Fact]
         public void CtorTest()
         {
-            Query query = new Query(new SchoolServiceMock())
+            Query query = new Query()
             {
                 Class = 10,
                 Social = 10.0,
@@ -24,7 +24,8 @@ namespace KonSchool.Tests.ModelTests
                 },
                 Weights = new double[] { 0.1667, 0.1667, 0.1667, 0.1667, 0.1667, 0.1667 },
                 LimitByDistrict = false,
-                LimitByDivision = false
+                LimitByDivision = false,
+                _SchoolService = new SchoolServiceMock()
             };
 
             Assert.Equal(6, query.Alternatives.Count);
@@ -34,7 +35,10 @@ namespace KonSchool.Tests.ModelTests
         [Fact]
         public void Can_SetLocation()
         {
-            Query query = new Query(new SchoolServiceMock());
+            Query query = new Query()
+            {
+                _SchoolService = new SchoolServiceMock()
+            };
             query.SetLocation("Dhaka", "Dhaka", "Rampura", "Ward no. 1");
             Assert.Equal("Dhaka", query.Division);
             Assert.Equal("Dhaka", query.District);
@@ -45,7 +49,7 @@ namespace KonSchool.Tests.ModelTests
         [Fact]
         public void Can_CheckEligibility_Female()
         {
-            Query query = new Query(new SchoolServiceMock())
+            Query query = new Query()
             {
                 Class = 10,
                 Social = 10.0,
@@ -61,7 +65,8 @@ namespace KonSchool.Tests.ModelTests
                 LimitByDistrict = false,
                 LimitByDivision = true,
                 Division = "Dhaka",
-                District = "Dhaka"
+                District = "Dhaka",
+                _SchoolService = new SchoolServiceMock()
             };
 
             query.SetValues();
@@ -77,7 +82,7 @@ namespace KonSchool.Tests.ModelTests
         [Fact]
         public void Can_CheckEligibility_Male()
         {
-            Query query = new Query(new SchoolServiceMock())
+            Query query = new Query()
             {
                 Class = 7,
                 Social = 10.0,
@@ -91,7 +96,8 @@ namespace KonSchool.Tests.ModelTests
                 },
                 Weights = new double[] { 0.1667, 0.1667, 0.1667, 0.1667, 0.1667, 0.1667 },
                 LimitByDistrict = false,
-                LimitByDivision = false
+                LimitByDivision = false,
+                _SchoolService = new SchoolServiceMock()
             };
 
             query.SetValues();

--- a/tests/PageModelTests/IndexModel.test.cs
+++ b/tests/PageModelTests/IndexModel.test.cs
@@ -14,7 +14,7 @@ namespace KonSchool.Tests.PageModelTests
         [Fact]
         public void Can_OnGet()
         {
-            var indexPage = new IndexModel(new Query(new SchoolServiceMock()));
+            var indexPage = new IndexModel(new Query());
             indexPage.OnGet();
             Assert.Equal(NUMBER_OF_CLASSES, indexPage.Classes.Count);
             Assert.Equal(NUMBER_OF_OCCUPATIONS, indexPage.Occupations.Count);
@@ -23,7 +23,7 @@ namespace KonSchool.Tests.PageModelTests
         [Fact]
         public void Can_RedirectTo_InputsPage_OnPost()
         {
-            var indexPage = new IndexModel(new Query(new SchoolServiceMock()))
+            var indexPage = new IndexModel(new Query())
             {
                 Class = "6",
                 Division = "Dhaka",

--- a/tests/PageModelTests/InputsModel.test.cs
+++ b/tests/PageModelTests/InputsModel.test.cs
@@ -12,7 +12,7 @@ namespace KonSchool.Tests.PageModelTests
         [Fact]
         public void Can_OnGet()
         {
-            var inputsModel = new InputsModel(new Query(new SchoolServiceMock()));
+            var inputsModel = new InputsModel(new Query());
             inputsModel.OnGet();
             Assert.NotNull(inputsModel.Values);
         }
@@ -20,7 +20,7 @@ namespace KonSchool.Tests.PageModelTests
         [Fact]
         public void Can_RedirectTo_OutputsPage_OnPost()
         {
-            var inputsModel = new InputsModel(new Query(new SchoolServiceMock()));
+            var inputsModel = new InputsModel(new Query());
             inputsModel.OnGet();
             Assert.True(inputsModel.ModelState.IsValid);
             var response_on_submit = inputsModel.OnPost() as RedirectToPageResult;

--- a/tests/PageModelTests/OutputsModel.test.cs
+++ b/tests/PageModelTests/OutputsModel.test.cs
@@ -10,7 +10,7 @@ namespace KonSchool.Tests.PageModelTests
         [Fact]
         public void Can_OnGet()
         {
-            var outputsPage = new OutputsModel(new Query(new SchoolServiceMock()));
+            var outputsPage = new OutputsModel(new Query(), new SchoolServiceMock());
             outputsPage._Query.Weights = new double[] { 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 };
             outputsPage.OnGet();
             Assert.Equal(6, outputsPage.Criteria.Length);
@@ -19,7 +19,7 @@ namespace KonSchool.Tests.PageModelTests
         [Fact]
         public void Can_ConvertNumbers_ToShortNumber()
         {
-            var outputsPage = new OutputsModel(new Query(new SchoolServiceMock()));
+            var outputsPage = new OutputsModel(new Query(), new SchoolServiceMock());
             double number = 0.031416;
             string shortNumber = outputsPage.ToShortNumber(number);
             Assert.Equal("3.14%", shortNumber);


### PR DESCRIPTION
Prior to this change, the `SchoolService` would be loaded right at the beginning of the application, no matter what the app was being used for.

This slowed down the startup for the app. Moreover, this was not necessary for all the functionalities of the app, such as the `FAHPController`, which did not require `SchoolService` in any way.

This change fixes the problem by initiating `SchoolService` only when it was necessary — in `Outputs` page and for `SchoolsController`.